### PR TITLE
WIP: font fallback

### DIFF
--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -236,7 +236,6 @@ struct FontCache {
 
 struct DWriteContext {
     bool mDrawing;
-    HDC mHDC;
 
     ID2D1Factory *mD2D1Factory;
 
@@ -531,7 +530,6 @@ private:
 
 DWriteContext::DWriteContext() :
     mDrawing(false),
-    mHDC(NULL),
     mD2D1Factory(NULL),
     mRT(NULL),
     mBrush(NULL),
@@ -791,7 +789,6 @@ DWriteContext::SetFont(HFONT hFont)
 DWriteContext::BindDC(HDC hdc, RECT *rect)
 {
     Flush();
-    mHDC = hdc;
     mRT->BindDC(hdc, rect);
     mRT->SetTransform(D2D1::IdentityMatrix());
 }

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -6196,12 +6196,16 @@ RevOut( HDC s_hdc,
     static int
 gui_is_outline_font_selected(HDC hdc)
 {
+#if 0
     TEXTMETRIC tm;
 
     GetTextMetrics(hdc, &tm);
     if (tm.tmPitchAndFamily & (TMPF_TRUETYPE | TMPF_VECTOR))
 	return 1;
     return 0;
+#else
+    return 1;
+#endif
 }
 
     void


### PR DESCRIPTION
DirectX で使えないフォントが渡されたら、事前に準備したフォントにフォールバックする。

* フォールバック先は `Courier New:h12` 相当。日本語表示はアレになるが英語はそこそこ見られる。