### PR TITLE
Fix GTK flash visibility and off-by-one errors

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -1493,10 +1493,13 @@ gui_mch_flash(int msec)
     if (gui.surface == NULL)
 	return;
 
-    gui_mch_invert_rectangle(0, 0, (int)Rows - 1, (int)Columns - 1);
+    gui_mch_invert_rectangle(0, 0, (int)Rows, (int)Columns);
     gui_mch_flush();
+    gui_mch_update();
     ui_delay((long)msec, TRUE);
-    gui_mch_invert_rectangle(0, 0, (int)Rows - 1, (int)Columns - 1);
+    gui_mch_invert_rectangle(0, 0, (int)Rows, (int)Columns);
+    gui_mch_flush();
+    gui_mch_update();
 }
 
     void
@@ -1512,7 +1515,7 @@ gui_mch_invert_rectangle(int r, int c, int nr, int nc)
     cairo_set_source_rgb(cr, 1.0, 1.0, 1.0);
     cairo_rectangle(cr,
 	    FILL_X(c), FILL_Y(r),
-	    (nc + 1) * gui.char_width, (nr + 1) * gui.char_height);
+	    nc * gui.char_width, nr * gui.char_height);
     cairo_fill(cr);
     cairo_destroy(cr);
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6550,12 +6550,13 @@ gui_mch_flash(int msec)
     // Invert the screen, wait, then invert back
     if (gui.surface == NULL)
 	return;
-    gui_mch_invert_rectangle(0, 0, (int)Rows - 1, (int)Columns - 1);
+    gui_mch_invert_rectangle(0, 0, (int)Rows, (int)Columns);
+    gui_mch_flush();
+    gui_mch_update();
     ui_delay((long)msec, TRUE);
-    // Up to this point, the first inversion is not reflected on the screen. As
-    // a result, the next inversion reverts to the bottom, and the inversion
-    // effect cannot be visually confirmed.
-    gui_mch_invert_rectangle(0, 0, (int)Rows - 1, (int)Columns - 1);
+    gui_mch_invert_rectangle(0, 0, (int)Rows, (int)Columns);
+    gui_mch_flush();
+    gui_mch_update();
 #else
     GdkGCValues	values;
     GdkGC	*invert_gc;


### PR DESCRIPTION
Fixed the invisible screen flash effect in GTK3 and GTK4 by forcing UI updates between inversions and corrected off-by-one coordinate errors.

---
*PR created automatically by Jules for task [2886940988041535088](https://jules.google.com/task/2886940988041535088) started by @koron*